### PR TITLE
add support for n/o security sensors (by inverting the port in config)

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=OXRS-IO-IOHandler-ESP32-LIB
-version=1.4.2
+version=1.4.3
 author=OXRS Core Team
 maintainer=Ben Jones <ben.jones@gmail.com>
 sentence=ESP32 I/O handler library for Open eXtensible Rack System firmware

--- a/src/OXRS_Input.h
+++ b/src/OXRS_Input.h
@@ -178,7 +178,7 @@ class OXRS_Input
     uint16_t _getDebounceLowTime(uint8_t type);
     uint16_t _getDebounceHighTime(uint8_t type);
     
-    uint8_t _getSecurityState(uint8_t securityValue[]);
+    uint8_t _getSecurityState(uint8_t securityValue[], uint8_t invert);
     uint8_t _getSecurityEvent(uint8_t securityState);
     
     void _update(uint8_t state[], uint16_t value);


### PR DESCRIPTION
Hey Moin - came across something today I am hoping you can have a look at - Frank and I were testing the Monimod he sent me and I was getting inverted normal/alarm events out when my PIR tripped - turns out it is N/O instead of N/C (as most security sensors are). 

So I updated the IO/Handler to support inverting a security input (this PR) which would not invert any of the input signals, but just the output event generated - i.e. swapping normal -> alarm and vice versa. This worked and I now get the correct events out of my N/O PIR - but the LCD is showing the inverted colours... i.e. green for alarm, red for normal.

I am just thinking - would the LCD be screwed up if any type of input was inverted - i.e. if we have a N/C switch and set the config to inverted the LCD would still show the LED as on when the switch is closed, and off when it is open, even if the generated events would be inverted?

Interested in your thoughts on this - as I know it is moving us further away from your design of the LCD being a hardware monitor only