### PR TITLE
allow output handlers to be initialised with the default relay state …

### DIFF
--- a/src/OXRS_Output.cpp
+++ b/src/OXRS_Output.cpp
@@ -10,7 +10,7 @@
 #include "Arduino.h"
 #include "OXRS_Output.h"
 
-void OXRS_Output::begin(eventCallback callback, uint8_t defaultType) 
+void OXRS_Output::begin(eventCallback callback, uint8_t defaultType, uint8_t defaultState)
 {
   // Store a reference to our event callback
   _callback = callback; 
@@ -24,8 +24,8 @@ void OXRS_Output::begin(eventCallback callback, uint8_t defaultType)
     setTimer(i, DEFAULT_TIMER_SECS);
 
     // Initialise our output state
-    _state[i].data.current = RELAY_OFF;
-    _state[i].data.next = RELAY_OFF;
+    _state[i].data.current = defaultState;
+    _state[i].data.next = defaultState;
     _state[i].data.id = 0;
 
     _eventTime[i] = 0;

--- a/src/OXRS_Output.h
+++ b/src/OXRS_Output.h
@@ -53,7 +53,7 @@ class OXRS_Output
 {
   public:
     // Initialise the output handler
-    void begin(eventCallback, uint8_t defaultType=RELAY);
+    void begin(eventCallback, uint8_t defaultType=RELAY, uint8_t defaultState=RELAY_OFF);
 
     // Get/Set the output type
     uint8_t getType(uint8_t output);


### PR DESCRIPTION
…(i.e. normally RELAY_OFF, but RELAY_ON for NC relays)