### PR TITLE
relay logic ifndef

### DIFF
--- a/src/OXRS_Output.h
+++ b/src/OXRS_Output.h
@@ -17,8 +17,12 @@
 #define OUTPUT_COUNT                16
 
 // Event constants
+#ifndef RELAY_ON
 #define RELAY_ON                    HIGH
+#endif
+#ifndef RELAY_OFF
 #define RELAY_OFF                   LOW
+#endif
 
 // Delay between an interlocked deactivation/activation
 #define RELAY_INTERLOCK_DELAY_MS    500


### PR DESCRIPTION
this will allow firmware like KINCONY to use build flags in invert relay logic and have everything function normally and in the same manor as existing firmware with minimal changes required to accomplish it's task.